### PR TITLE
Updating Requirements to be More Browser Friendly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "usps-webtools-angular",
+  "name": "usps-webtools",
   "author": "Sherod Taylor <sherodtaylor@gmail.com>",
   "description": "Api wrapper for the USPS Web-Tools",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "main": "./src/usps",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pbtura/usps-webtools"
+    "url": "https://github.com/MadisonReed/usps-webtools.git"
   },
   "contributors": [
     {
@@ -32,7 +32,7 @@
     "standardization"
   ],
   "dependencies": {
-    "browser-request": "",
+    "request": "2.50.0",
     "xml2js": "0.4.4",
     "xmlbuilder": "2.1.0"
   },
@@ -40,7 +40,7 @@
     "mocha": "1.17.1",
     "chai": "1.9.0"
   },
-  "repository": "https://github.com/pbtura/usps-webtools",
+  "repository": "https://github.com/MadisonReed/usps-webtools.git",
   "engines": {
     "node": ">=0.10.20"
   },

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "standardization"
   ],
   "dependencies": {
-    "angular": "1.4.x",
-    "request": "2.34.0",
+    "browser-request": "",
     "xml2js": "0.4.4",
     "xmlbuilder": "2.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "usps-webtools",
+  "name": "usps-webtools-angular",
   "author": "Sherod Taylor <sherodtaylor@gmail.com>",
   "description": "Api wrapper for the USPS Web-Tools",
   "version": "0.0.10",
   "main": "./src/usps",
   "repository": {
     "type": "git",
-    "url": "https://github.com/MadisonReed/usps-webtools.git"
+    "url": "https://github.com/pbtura/usps-webtools"
   },
   "contributors": [
     {
@@ -32,6 +32,7 @@
     "standardization"
   ],
   "dependencies": {
+    "angular": "1.4.x",
     "request": "2.34.0",
     "xml2js": "0.4.4",
     "xmlbuilder": "2.1.0"
@@ -40,7 +41,7 @@
     "mocha": "1.17.1",
     "chai": "1.9.0"
   },
-  "repository": "git://github.com/MadisonReed/usps-webtools",
+  "repository": "https://github.com/pbtura/usps-webtools",
   "engines": {
     "node": ">=0.10.20"
   },

--- a/src/usps.js
+++ b/src/usps.js
@@ -1,5 +1,5 @@
 // external dependencies
-var request = require('browser-request');
+var request = require('request');
 var builder = require('xmlbuilder');
 var xml2js = require('xml2js');
 

--- a/src/usps.js
+++ b/src/usps.js
@@ -46,16 +46,22 @@ usps.prototype.verify = function(address, callback) {
       return;
     }
 
-    callback(null, {
-      firmName: address.FirmName[0],
+    var result = {
+
       street1: address.Address2[0],
       street2: address.Address1 ? address.Address1[0] : '',
       city: address.City[0],
       zip: address.Zip5[0],
       state: address.State[0],
-      zip4: address.Zip4[0],
-      urbanization: address.Urbanization[0]
-    });
+      zip4: address.Zip4[0]
+    };
+    if(address.FirmName) {
+      result.firmName = address.FirmName[0]
+    }
+    if(address.Urbanization) {
+      result.urbanization = address.Urbanization[0];
+    }
+    callback(null, result);
   });
 
   return this;

--- a/src/usps.js
+++ b/src/usps.js
@@ -34,11 +34,17 @@ usps.prototype.verify = function(address, callback) {
       Address2: address.street1,
       City: address.city,
       State: address.state,
-      Zip5: address.zip,
-      Zip4: address.zip4,
-      Urbanization: address.urbanization
+      Zip5: address.zip
     }
   };
+  if(address.zip4)
+  {
+    obj.Address.Zip4 = address.zip4;
+  }
+  if(address.urbanization)
+  {
+    obj.Address.Urbanization = address.urbanization;
+  }
 
   callUSPS('Verify', 'AddressValidateRequest', 'AddressValidateResponse.Address', this.config, obj, function(err, address) {
     if (err) {

--- a/src/usps.js
+++ b/src/usps.js
@@ -29,12 +29,14 @@ var usps = module.exports = function(config) {
 usps.prototype.verify = function(address, callback) {
   var obj = {
     Address: {
+      FirmName: address.firmName,
       Address1: address.street2 || '',
       Address2: address.street1,
       City: address.city,
       State: address.state,
       Zip5: address.zip,
-      Zip4: ''
+      Zip4: address.zip4,
+      Urbanization: address.urbanization
     }
   };
 
@@ -45,11 +47,14 @@ usps.prototype.verify = function(address, callback) {
     }
 
     callback(null, {
+      firmName: address.FirmName[0],
       street1: address.Address2[0],
       street2: address.Address1 ? address.Address1[0] : '',
       city: address.City[0],
       zip: address.Zip5[0],
-      state: address.State[0]
+      state: address.State[0],
+      zip4: address.Zip4[0],
+      urbanization: address.Urbanization[0]
     });
   });
 

--- a/src/usps.js
+++ b/src/usps.js
@@ -1,5 +1,5 @@
 // external dependencies
-var request = require('request');
+var request = require('browser-request');
 var builder = require('xmlbuilder');
 var xml2js = require('xml2js');
 

--- a/src/usps.js
+++ b/src/usps.js
@@ -34,13 +34,11 @@ usps.prototype.verify = function(address, callback) {
       Address2: address.street1,
       City: address.city,
       State: address.state,
-      Zip5: address.zip
+      Zip5: address.zip,
+      Zip4: address.zip4 ? address.zip4 : ''
     }
   };
-  if(address.zip4)
-  {
-    obj.Address.Zip4 = address.zip4;
-  }
+
   if(address.urbanization)
   {
     obj.Address.Urbanization = address.urbanization;

--- a/src/usps.js
+++ b/src/usps.js
@@ -29,7 +29,7 @@ var usps = module.exports = function(config) {
 usps.prototype.verify = function(address, callback) {
   var obj = {
     Address: {
-      FirmName: address.firmName,
+      FirmName: address.firm_name,
       Address1: address.street2 || '',
       Address2: address.street1,
       City: address.city,
@@ -60,7 +60,7 @@ usps.prototype.verify = function(address, callback) {
       zip4: address.Zip4[0]
     };
     if(address.FirmName) {
-      result.firmName = address.FirmName[0]
+      result.firm_name = address.FirmName[0]
     }
     if(address.Urbanization) {
       result.urbanization = address.Urbanization[0];


### PR DESCRIPTION
Replaced the dependency on the 'request' library with a newer version (2.50.0) to make it possible to use this library on the client via browserify. Also implemented missing fields from the usps api (FirmName, Urbanization, and Zip4). 
