### PR TITLE
Update qs, request, hawk due to security vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "Api wrapper for the USPS Web-Tools",
   "version": "0.0.10",
   "main": "./src/usps",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/MadisonReed/usps-webtools.git"
-  },
+  "repository": "git://github.com/MadisonReed/usps-webtools",
   "contributors": [
     {
       "name": "Sherod Taylor",
@@ -32,7 +29,7 @@
     "standardization"
   ],
   "dependencies": {
-    "request": "2.34.0",
+    "request": "^2.78.0",
     "xml2js": "0.4.4",
     "xmlbuilder": "2.1.0"
   },
@@ -40,7 +37,6 @@
     "mocha": "1.17.1",
     "chai": "1.9.0"
   },
-  "repository": "git://github.com/MadisonReed/usps-webtools",
   "engines": {
     "node": ">=0.10.20"
   },


### PR DESCRIPTION
These updates are purely updating security vulnerabilities, no major/breaking changes.