### PR TITLE
Have USPSError class call super()

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -15,6 +15,8 @@
 */
 class USPSError extends Error {
   constructor(message, ...additions) {
+    super(message);
+
     // addition should be an {} obj (possibly an Error)
     for (let addition of additions) {
       for (let key in addition) {

--- a/test/city-test.js
+++ b/test/city-test.js
@@ -3,7 +3,7 @@ const { test } = require('ava');
 
 const usps = new USPS({
   server: 'http://production.shippingapis.com/ShippingAPI.dll',
-  userId: '##'
+  userId: process.env.USPS_USER_ID
 });
 
 test.cb('#cityStateLookup() should return the city when passed a zipcode', t => {

--- a/test/validator-test.js
+++ b/test/validator-test.js
@@ -3,7 +3,7 @@ const { test } = require('ava');
 
 const usps = new USPS({
   server: 'http://production.shippingapis.com/ShippingAPI.dll',
-  userId: '##'
+  userId: process.env.USPS_USER_ID
 });
 
 test.cb('Address verify should validate apartment', t => {

--- a/test/zipcode-test.js
+++ b/test/zipcode-test.js
@@ -3,7 +3,7 @@ const { test } = require('ava');
 
 const usps = new USPS({
   server: 'http://production.shippingapis.com/ShippingAPI.dll',
-  userId: '##'
+  userId: process.env.USPS_USER_ID
 });
 
 const ZIP = '94607-3785';


### PR DESCRIPTION
Anytime an error would come in, `USPSError` would fail to init with this, and it would kill my server :(

```sh
ReferenceError: Must call super constructor in derived class before accessing 'this' or returning from derived constructor
new USPSError (src/error.js:23:9)
xml2js.parseString (src/usps.js:275:25)
Parser.<anonymous> (node_modules/xml2js/lib/xml2js.js:384:20)
SAXParser.onclosetag (node_modules/xml2js/lib/xml2js.js:348:26)
emit (node_modules/sax/lib/sax.js:615:33)
emitNode (node_modules/sax/lib/sax.js:620:3)
closeTag (node_modules/sax/lib/sax.js:861:5)
SAXParser.write (node_modules/sax/lib/sax.js:1294:29)
Parser.exports.Parser.Parser.parseString (node_modules/xml2js/lib/xml2js.js:403:31)
Parser.parseString (node_modules/xml2js/lib/xml2js.js:6:61)
Object.exports.parseString (node_modules/xml2js/lib/xml2js.js:433:19)
Request.request [as _callback] (src/usps.js:235:12)
Request.self.callback (node_modules/request/request.js:186:22)
```

This PR fixes by calling `super()` in the ctor.

Another change here is using an environment var for the test user id. You can now run tests via 

```sh
$ USPS_USER_ID=1234MYUID567 npm test
```